### PR TITLE
change the faultCode from CLIENT to SERVER to return status code 500 …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM eclipse-temurin:11-jre-jammy
+FROM eclipse-temurin:11-jre-alpine
+
+RUN apk upgrade expat  # Fix for CVE-2022-43680
 
 COPY ./pcss-civil-application/target/pcss-civil-application.jar pcss-civil-application.jar
 

--- a/pcss-civil-application/src/main/java/ca/bc/gov/open/pcss/exceptions/ORDSException.java
+++ b/pcss-civil-application/src/main/java/ca/bc/gov/open/pcss/exceptions/ORDSException.java
@@ -4,7 +4,7 @@ import org.springframework.ws.soap.server.endpoint.annotation.FaultCode;
 import org.springframework.ws.soap.server.endpoint.annotation.SoapFault;
 
 @SoapFault(
-        faultCode = FaultCode.CLIENT,
+        faultCode = FaultCode.SERVER,
         faultStringOrReason =
                 "An error response was received from ORDS please check that your request is of valid form")
 public class ORDSException extends RuntimeException {

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <log4j2.version>2.17.1</log4j2.version>
         <java.version>11</java.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
+        <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
…back to SOAP UI

# Description

This PR includes the following proposed change(s):

- {[List all the changes, if possible add the jira ticket #](https://justice.gov.bc.ca/jira/browse/JADE-1774])}

## Type of change

-currently, PCSS returns status 400 (bad request) even if ORDS throws exceptions, see the attachment. The correct way is to show the status 500 to SOAP front.

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
